### PR TITLE
chore: Bump ver: 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "watcher"
 description = "subscribe data changes"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/src/dispatch/dispatcher.rs
+++ b/src/dispatch/dispatcher.rs
@@ -120,7 +120,7 @@ where C: TypeConfig
                 continue;
             }
 
-            let resp = C::new_response(kv_change.clone());
+            let resp = C::new_change_response(kv_change.clone());
             if let Err(_err) = sender.send(resp).await {
                 warn!(
                     "watch-event-Dispatcher: fail to send to watcher {:?}; close this stream",

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -16,7 +16,9 @@ use std::future::Future;
 use std::io;
 
 use crate::type_config::KVChange;
+use crate::type_config::KeyOf;
 use crate::type_config::TypeConfig;
+use crate::type_config::ValueOf;
 
 // Only Debug is actually needed for the test framework
 #[derive(Debug, Copy, Clone)]
@@ -28,7 +30,11 @@ impl TypeConfig for UTTypes {
     type Response = (String, Option<String>, Option<String>);
     type Error = io::Error;
 
-    fn new_response(change: KVChange<Self>) -> Self::Response {
+    fn new_flush_response(key: KeyOf<Self>, value: ValueOf<Self>) -> Self::Response {
+        (key, None, Some(value))
+    }
+
+    fn new_change_response(change: KVChange<Self>) -> Self::Response {
         change
     }
 

--- a/src/type_config.rs
+++ b/src/type_config.rs
@@ -67,8 +67,11 @@ where Self: Debug + Clone + Copy + Sized + 'static
     /// The type of errors returned to watchers.
     type Error: Error + Send + 'static;
 
+    /// Create a new response instance from existent key value pair.
+    fn new_flush_response(key: KeyOf<Self>, value: ValueOf<Self>) -> Self::Response;
+
     /// Create a response instance from a key-value change.
-    fn new_response(change: KVChange<Self>) -> Self::Response;
+    fn new_change_response(change: KVChange<Self>) -> Self::Response;
 
     /// Create an error when the data source returns io::Error
     fn data_error(error: io::Error) -> Self::Error;

--- a/tests/it/dispatcher.rs
+++ b/tests/it/dispatcher.rs
@@ -25,7 +25,9 @@ use watcher::dispatch::Dispatcher;
 use watcher::dispatch::DispatcherHandle;
 use watcher::event_filter::EventFilter;
 use watcher::type_config::KVChange;
+use watcher::type_config::KeyOf;
 use watcher::type_config::TypeConfig;
+use watcher::type_config::ValueOf;
 use watcher::watch_stream::WatchStreamSender;
 use watcher::KeyRange;
 use watcher::WatchResult;
@@ -45,7 +47,11 @@ impl TypeConfig for Types {
     type Response = (String, Option<String>, Option<String>);
     type Error = io::Error;
 
-    fn new_response(change: KVChange<Self>) -> Self::Response {
+    fn new_flush_response(key: KeyOf<Self>, value: ValueOf<Self>) -> Self::Response {
+        (key, None, Some(value))
+    }
+
+    fn new_change_response(change: KVChange<Self>) -> Self::Response {
         change
     }
 


### PR DESCRIPTION

## Changelog

##### chore: Bump ver: 0.3.0

##### change: separate flush-resp and watch-resp
Distinguish between two watch service event types:

- Initial flush response: When a watcher connects, all existing
  key-value pairs `(key, value)` are sent
- Change response: When a key-value changes, containing `(key,
  before-value, after-value)`

This commit modifies `TypeConfig` to split the previous `new_response`
method into two distinct methods:
- `new_flush_response`
- `new_change_response`

This separation allows applications to properly distinguish between
these two event types.

---