### PR TITLE
chore: Bump ver: 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "watcher"
 description = "subscribe data changes"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/src/dispatch/dispatcher.rs
+++ b/src/dispatch/dispatcher.rs
@@ -153,8 +153,6 @@ where C: TypeConfig
         self.watchers
             .insert(stream_sender.desc.key_range.clone(), stream_sender.clone());
 
-        C::update_watcher_metrics(1);
-
         Arc::downgrade(&stream_sender)
     }
 
@@ -172,8 +170,6 @@ where C: TypeConfig
         );
 
         self.watchers.remove(.., stream_sender);
-
-        C::update_watcher_metrics(-1);
     }
 
     #[allow(clippy::mutable_key_type)]

--- a/src/watch_stream/sender.rs
+++ b/src/watch_stream/sender.rs
@@ -40,6 +40,8 @@ impl<C> Drop for WatchStreamSender<C>
 where C: TypeConfig
 {
     fn drop(&mut self) {
+        C::update_watcher_metrics(-1);
+
         debug!("WatchStreamSender({:?}) dropped", self.desc,);
     }
 }
@@ -92,6 +94,7 @@ impl<C> WatchStreamSender<C>
 where C: TypeConfig
 {
     pub fn new(desc: WatchDesc<C>, tx: mpsc::Sender<WatchResult<C>>) -> Self {
+        C::update_watcher_metrics(1);
         WatchStreamSender { desc, tx }
     }
 

--- a/tests/it/dispatcher.rs
+++ b/tests/it/dispatcher.rs
@@ -16,7 +16,10 @@ use std::collections::BTreeSet;
 use std::future::Future;
 use std::io;
 use std::ops::Bound;
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -36,6 +39,9 @@ use watcher::WatchResult;
 const REMOVAL_DELAY: Duration = Duration::from_millis(300);
 const RECEIVE_TIMEOUT: Duration = Duration::from_millis(1000);
 const CHECK_NEGATIVE_TIMEOUT: Duration = Duration::from_millis(100);
+
+// Sender count metrics container.
+static SENDER_COUNT: AtomicI64 = AtomicI64::new(0);
 
 // Only Debug is actually needed for the test framework
 #[derive(Debug, Copy, Clone)]
@@ -59,7 +65,9 @@ impl TypeConfig for Types {
         error
     }
 
-    fn update_watcher_metrics(_delta: i64) {}
+    fn update_watcher_metrics(delta: i64) {
+        SENDER_COUNT.fetch_add(delta, Ordering::Relaxed);
+    }
 
     #[allow(clippy::disallowed_methods)]
     fn spawn<T>(fut: T)
@@ -327,6 +335,49 @@ async fn test_dispatcher_closed_channel() {
     tokio::time::sleep(REMOVAL_DELAY).await;
     let senders = all_senders(&handle).await;
     assert_eq!(senders.len(), 0);
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn test_metrics() {
+    // Metrics is reported to global metrics collector, so we need to protect it with a mutex
+    static MUTEX: Mutex<()> = Mutex::new(());
+
+    let _guard = MUTEX.lock().unwrap();
+    SENDER_COUNT.store(0, Ordering::Relaxed);
+
+    let handle = Dispatcher::<Types>::spawn();
+
+    {
+        // Add a watcher, sender count should be 1
+
+        let (tx, _rx) = mpsc::channel(10);
+        let weak_sender = handle
+            .add_watcher(rng("a", "c"), EventFilter::update(), tx)
+            .await
+            .unwrap();
+
+        let sender_count = SENDER_COUNT.load(Ordering::Relaxed);
+        assert_eq!(sender_count, 1);
+
+        // Remove a watcher, sender count should still be 1, because the watcher is not dropped yet
+
+        let sender = weak_sender.upgrade().unwrap();
+
+        handle.remove_watcher(sender.clone()).await.unwrap();
+        let sender_count = SENDER_COUNT.load(Ordering::Relaxed);
+        assert_eq!(sender_count, 1);
+
+        // Remove Again, sender count should be 1, because the watcher is not dropped yet
+        handle.remove_watcher(sender.clone()).await.unwrap();
+        let sender_count = SENDER_COUNT.load(Ordering::Relaxed);
+        assert_eq!(sender_count, 1);
+    }
+
+    // Drop the handle, sender count should be 0
+
+    let sender_count = SENDER_COUNT.load(Ordering::Relaxed);
+    assert_eq!(sender_count, 0);
 }
 
 fn s(x: &str) -> String {


### PR DESCRIPTION
## Changelog

##### chore: Bump ver: 0.4.1

##### fix: metrics should be updated when sender is created and dropped
But not when it is added to or removed from the `Dispatcher`.
Because a sender can be removed more than once, since internally the
dispatcher is a span-map, it stores multiple instance of a sender.

This should fix the negative watcher number issue:

<img width="293" alt="image" src="https://github.com/user-attachments/assets/2ead2bda-06b0-4850-bd38-882452c7ed14" />


---


- Bug Fix