### PR TITLE
chore: Bump ver: 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "watcher"
 description = "subscribe data changes"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,77 @@
-# watcher
-A watcher is a stream subscribing data changes
+# Watcher
+
+A library for subscribing to key-value data changes.
+
+## Overview
+
+Watch for changes in specific key ranges and get notified when data is updated or deleted. Useful for building reactive systems that need to respond to data changes.
+
+## Features
+
+- **Range-based watching** - Monitor key ranges instead of individual keys
+- **Event filtering** - Choose to receive updates, deletes, or both
+- **Multiple watchers** - Support concurrent watchers with different ranges and filters
+- **Generic types** - Customize key/value types for any storage backend
+- **Async streaming** - Built on tokio with non-blocking event delivery
+- **Automatic cleanup** - Resources cleaned up when watchers are dropped
+- **Efficient routing** - Fast event dispatch to interested watchers only
+
+## Usage
+
+```rust
+use std::ops::Bound;
+use watcher::{Dispatcher, EventFilter, TypeConfig};
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone, Copy)]
+struct Config;
+
+impl TypeConfig for Config {
+    type Key = String;
+    type Value = String;
+    type Response = (String, Option<String>, Option<String>);
+    type Error = std::io::Error;
+
+    fn new_initialize_response(key: Self::Key, value: Self::Value) -> Self::Response {
+        (key, None, Some(value))
+    }
+
+    fn new_change_response(change: (Self::Key, Option<Self::Value>, Option<Self::Value>)) -> Self::Response {
+        change
+    }
+
+    fn data_error(error: std::io::Error) -> Self::Error { error }
+    fn update_watcher_metrics(_delta: i64) {}
+    fn spawn<T>(fut: T) where T: std::future::Future + Send + 'static, T::Output: Send + 'static {
+        tokio::spawn(fut);
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let dispatcher = Dispatcher::<Config>::spawn();
+    
+    let (tx, mut rx) = mpsc::channel(10);
+    let _watcher = dispatcher.add_watcher(
+        (Bound::Included("a".to_string()), Bound::Excluded("z".to_string())),
+        EventFilter::all(),
+        tx
+    ).await.unwrap();
+    
+    dispatcher.send_change(("key1".to_string(), None, Some("value1".to_string())));
+    
+    if let Some(Ok(event)) = rx.recv().await {
+        println!("Received: {:?}", event);
+    }
+}
+```
+
+## Event Filters
+
+- `EventFilter::all()` - Watch both updates and deletes
+- `EventFilter::update()` - Watch only updates  
+- `EventFilter::delete()` - Watch only deletes
+
+## License
+
+Apache-2.0

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -15,3 +15,4 @@
 #![allow(clippy::mutable_key_type)]
 
 mod dispatcher;
+mod metrics;

--- a/tests/it/metrics.rs
+++ b/tests/it/metrics.rs
@@ -1,0 +1,112 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::Bound;
+use std::future::Future;
+use std::io;
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering;
+
+use tokio::sync::mpsc;
+use watcher::dispatch::Dispatcher;
+use watcher::type_config::KVChange;
+use watcher::type_config::KeyOf;
+use watcher::type_config::TypeConfig;
+use watcher::type_config::ValueOf;
+use watcher::EventFilter;
+use watcher::KeyRange;
+
+// Sender count metrics container.
+static SENDER_COUNT: AtomicI64 = AtomicI64::new(0);
+
+// Only Debug is actually needed for the test framework
+#[derive(Debug, Copy, Clone)]
+struct Types {}
+
+impl TypeConfig for Types {
+    type Key = String;
+    type Value = String;
+    type Response = (String, Option<String>, Option<String>);
+    type Error = io::Error;
+
+    fn new_initialize_response(key: KeyOf<Self>, value: ValueOf<Self>) -> Self::Response {
+        (key, None, Some(value))
+    }
+
+    fn new_change_response(change: KVChange<Self>) -> Self::Response {
+        change
+    }
+
+    fn data_error(error: io::Error) -> Self::Error {
+        error
+    }
+
+    fn update_watcher_metrics(delta: i64) {
+        SENDER_COUNT.fetch_add(delta, Ordering::Relaxed);
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    fn spawn<T>(fut: T)
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static,
+    {
+        tokio::spawn(fut);
+    }
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn test_metrics() {
+    let handle = Dispatcher::<Types>::spawn();
+
+    {
+        // Add a watcher, sender count should be 1
+
+        let (tx, _rx) = mpsc::channel(10);
+        let weak_sender = handle
+            .add_watcher(rng("a", "c"), EventFilter::update(), tx)
+            .await
+            .unwrap();
+
+        let sender_count = SENDER_COUNT.load(Ordering::Relaxed);
+        assert_eq!(sender_count, 1);
+
+        // Remove a watcher, sender count should still be 1, because the watcher is not dropped yet
+
+        let sender = weak_sender.upgrade().unwrap();
+
+        handle.remove_watcher(sender.clone()).await.unwrap();
+        let sender_count = SENDER_COUNT.load(Ordering::Relaxed);
+        assert_eq!(sender_count, 1);
+
+        // Remove Again, sender count should be 1, because the watcher is not dropped yet
+        handle.remove_watcher(sender.clone()).await.unwrap();
+        let sender_count = SENDER_COUNT.load(Ordering::Relaxed);
+        assert_eq!(sender_count, 1);
+    }
+
+    // Drop the handle, sender count should be 0
+
+    let sender_count = SENDER_COUNT.load(Ordering::Relaxed);
+    assert_eq!(sender_count, 0);
+}
+
+fn s(x: &str) -> String {
+    x.to_string()
+}
+
+fn rng(start: &str, end: &str) -> KeyRange<Types> {
+    (Bound::Included(s(start)), Bound::Excluded(s(end)))
+}


### PR DESCRIPTION

## Changelog

##### chore: Bump ver: 0.4.2

##### feat: separate watch stream create and insert
Remove per-dispatcher watcher id, use global watcher id generator to
avoid accessing `Dispatcher` instance when building a watcher. Now it
does not need to access `Dispatcher` instance before inserting the watch
stream sender.


##### docs: add README.md

---