### PR TITLE
chore: Bump Ver: 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "watcher"
 description = "subscribe data changes"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
 use std::io;
 
 use crate::type_config::KVChange;
@@ -43,13 +42,4 @@ impl TypeConfig for UTTypes {
     }
 
     fn update_watcher_metrics(_delta: i64) {}
-
-    #[allow(clippy::disallowed_methods)]
-    fn spawn<T>(_fut: T)
-    where
-        T: Future + Send + 'static,
-        T::Output: Send + 'static,
-    {
-        todo!()
-    }
 }

--- a/src/type_config.rs
+++ b/src/type_config.rs
@@ -17,7 +17,6 @@
 use std::error::Error;
 use std::fmt::Debug;
 use std::fmt::Display;
-use std::future::Future;
 use std::io;
 
 /// A key-value change event: (key, old_value, new_value)
@@ -81,14 +80,4 @@ where Self: Debug + Clone + Copy + Sized + 'static
     /// # Arguments
     /// * `delta` - The change in watcher count (positive for increment, negative for decrement)
     fn update_watcher_metrics(delta: i64);
-
-    /// Spawn a task in the provided runtime.
-    ///
-    /// This is used to spawn a [`Dispatcher`] task running in the background.
-    ///
-    /// [`Dispatcher`]: crate::dispatch::Dispatcher
-    fn spawn<T>(fut: T)
-    where
-        T: Future + Send + 'static,
-        T::Output: Send + 'static;
 }


### PR DESCRIPTION

## Changelog

##### chore: Bump Ver: 0.5.0

##### change: decouple Dispatcher from runtime spawn
Replace `Dispatcher::spawn()` with `Dispatcher::create()` that returns
both the handle and main future, allowing callers to spawn the task
themselves. This removes the runtime coupling from `TypeConfig`.

Changes:
- Replace `Dispatcher::spawn()` with `Dispatcher::create()` returning `(DispatcherHandle, impl Future)`
- Remove `spawn()` method from `TypeConfig` trait

Upgrade tip:

Replace `Dispatcher::spawn()` with manual spawning:
- `let handle = Dispatcher::<T>::spawn();` → `let (handle, fut) = Dispatcher::<T>::create(); tokio::spawn(fut);`

Remove `spawn()` implementation from your `TypeConfig` impl.

---


